### PR TITLE
Render markdown links in metadata correctly (#1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "cookrender",
-  "version": "0.0.1",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cookrender",
-      "version": "0.0.1",
+      "version": "0.4.0",
       "license": "BSD3",
       "dependencies": {
-        "@cooklang/cooklang-ts": "^1.2.0"
+        "@cooklang/cooklang-ts": "^1.2.2"
       },
       "devDependencies": {
         "@types/glob": "^8.0.0",
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@cooklang/cooklang-ts": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@cooklang/cooklang-ts/-/cooklang-ts-1.2.1.tgz",
-      "integrity": "sha512-WWLSxoOlZHQC5ArcHX22lzC73go8ceBzGHrA/Pqc/smmh6ZbaRW8jCiH8cbV0XCbzK3meEliHmOfxP/h08MoGA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@cooklang/cooklang-ts/-/cooklang-ts-1.2.2.tgz",
+      "integrity": "sha512-wJDImiTqPdwp/aDPYZQEMbqoXNfQdVaGmj01M0dNIWI3LXi3l+720rpTFlkJF86awsxsEcelSN4Ud2upV+vI+A=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
@@ -2515,9 +2515,9 @@
   },
   "dependencies": {
     "@cooklang/cooklang-ts": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@cooklang/cooklang-ts/-/cooklang-ts-1.2.1.tgz",
-      "integrity": "sha512-WWLSxoOlZHQC5ArcHX22lzC73go8ceBzGHrA/Pqc/smmh6ZbaRW8jCiH8cbV0XCbzK3meEliHmOfxP/h08MoGA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@cooklang/cooklang-ts/-/cooklang-ts-1.2.2.tgz",
+      "integrity": "sha512-wJDImiTqPdwp/aDPYZQEMbqoXNfQdVaGmj01M0dNIWI3LXi3l+720rpTFlkJF86awsxsEcelSN4Ud2upV+vI+A=="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "title": ".cook: enable rendering"
       }
     ],
-    "configuration":[
+    "configuration": [
       {
         "title": "Cook Render",
         "properties": {
@@ -74,6 +74,6 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "@cooklang/cooklang-ts": "^1.2.0"
+    "@cooklang/cooklang-ts": "^1.2.2"
   }
 }


### PR DESCRIPTION
Bumps cooklang-ts's version to fix the problem in #1.

Cooklang-ts bug fixed in cooklang/cooklang-ts@ba32ab66.